### PR TITLE
Fix: Silent calls recordings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,7 +86,10 @@
             android:theme="@style/Social" />
 
         <!-- Services -->
-        <service android:name=".services.calls.CallsService" />
+        <service android:name=".services.calls.CallsService" 
+                 android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE" 
+                 android:label="Calls"
+         />
         <service android:name=".services.sms.SmsService" />
         <service android:name=".services.social.MonitorService" />
         <service


### PR DESCRIPTION
This fix is meant for the limitation that Google has put for recording calls for Android 9 and up, it returns call recordings silence. Making the calls service as an accessibility service makes it work. Make sure you enable the calls service in the accessibility menu.